### PR TITLE
feat: enhance FieldOptionsEvent with grouping and sorting capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [feature/grouped-options] - 02-02-2025
+- Added: ability to group options via the `FieldOptionsEvent`
+- Added: `FieldOptionsEvent` can now be enabled to sort options alphabetically
+- Added: fluent interface for `FieldOptionsEvent` setters
+- Changed: Removed default empty array parameter value from `FieldOptionsEvent::setOptions(array)`
+
 ## [0.2.8] - 2025-12-11
 - Added: english locales
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ class OptionsEventListener implements EventSubscriberInterface
         $event->addOption('adobe', 'Adobe');
         $event->addOption('istock', 'iStock');
     }
+    
+    public function onTopicOptions(FieldOptionsEvent $event): void
+    {
+        $event->addOption('cinema', 'Cinema', 'entertainment');
+        $event->addOption('music', 'Music', 'entertainment');
+        
+        $event->addOption('politics', 'Politics', 'news');
+        $event->addOption('sport', 'Sport', 'news');
+        $event->addOption('culture', 'Culture', 'news');
+    }
 }
 ```
 

--- a/src/Event/FieldOptionsEvent.php
+++ b/src/Event/FieldOptionsEvent.php
@@ -51,7 +51,7 @@ class FieldOptionsEvent extends Event
         ];
     }
 
-    public function setOptions(array $options = []): self
+    public function setOptions(array $options): self
     {
         $this->options = $options;
         $this->dirty = true;
@@ -95,7 +95,7 @@ class FieldOptionsEvent extends Event
      * values.
      *
      * @param array $values The option values
-     * @param array $reference A optional language array
+     * @param array $reference An optional language array
      */
     public function setOptionsByValues(array $values, array $reference = []): self
     {

--- a/src/Event/FieldOptionsEvent.php
+++ b/src/Event/FieldOptionsEvent.php
@@ -10,7 +10,8 @@ class FieldOptionsEvent extends Event
 {
     private bool $dirty = false;
     private bool $emptyOption = false;
-    private bool $grouped = false;
+    private ?bool $grouped = null;
+    private bool $autoGrouped = false;
     private bool $sorted = false;
 
     private string $emptyOptionLabel = '-';
@@ -35,6 +36,11 @@ class FieldOptionsEvent extends Event
     {
         $this->options[] = $this->createOptions($value, $label, $group);
         $this->dirty = true;
+
+        if (!\is_null($group)) {
+            $this->autoGrouped = true;
+        }
+
         return $this;
     }
 
@@ -70,10 +76,10 @@ class FieldOptionsEvent extends Event
 
     public function isGrouped(): bool
     {
-        return $this->grouped;
+        return $this->grouped ?? $this->autoGrouped;
     }
 
-    public function setGrouped(bool $grouped): self
+    public function setGrouped(?bool $grouped): self
     {
         $this->grouped = $grouped;
         return $this;

--- a/src/Event/FieldOptionsEvent.php
+++ b/src/Event/FieldOptionsEvent.php
@@ -9,14 +9,17 @@ use Symfony\Contracts\EventDispatcher\Event;
 class FieldOptionsEvent extends Event
 {
     private bool $dirty = false;
-
     private bool $emptyOption = false;
+    private bool $grouped = false;
+    private bool $sorted = false;
 
     private string $emptyOptionLabel = '-';
 
-    public function __construct(private readonly Widget $widget, private readonly Form $form, private array $options = [])
-    {
-    }
+    public function __construct(
+        private readonly Widget $widget,
+        private readonly Form   $form,
+        private array           $options = []
+    ) {}
 
     public function getWidget(): Widget
     {
@@ -28,28 +31,31 @@ class FieldOptionsEvent extends Event
         return $this->form;
     }
 
-    public function addOption(string $value, ?string $label = null): void
+    public function addOption(string $value, ?string $label = null, ?string $group = null): self
     {
-        $this->options[] = $this->createOptions($value, $label);
+        $this->options[] = $this->createOptions($value, $label, $group);
         $this->dirty = true;
+        return $this;
     }
 
-    public function createOptions(string $value, ?string $label = null): array
+    public function createOptions(string $value, ?string $label = null, ?string $group = null): array
     {
         if (!$label) {
             $label = $value;
         }
 
         return [
+            "group" => $group,
             "value" => $value,
             "label" => $label,
         ];
     }
 
-    public function setOptions(array $options = []): void
+    public function setOptions(array $options = []): self
     {
         $this->options = $options;
         $this->dirty = true;
+        return $this;
     }
 
     public function getOptions(): array
@@ -62,13 +68,36 @@ class FieldOptionsEvent extends Event
         return $this->dirty;
     }
 
+    public function isGrouped(): bool
+    {
+        return $this->grouped;
+    }
+
+    public function setGrouped(bool $grouped): self
+    {
+        $this->grouped = $grouped;
+        return $this;
+    }
+
+    public function isSorted(): bool
+    {
+        return $this->sorted;
+    }
+
+    public function setSorted(bool $sorted): self
+    {
+        $this->sorted = $sorted;
+        return $this;
+    }
+
     /**
-     * Set options by values. If a reference array is given, the values will be used as keys and the reference array as values.
+     * Set options by values. If a reference array is given, the values will be used as keys and the reference array as
+     * values.
      *
      * @param array $values The option values
      * @param array $reference A optional language array
      */
-    public function setOptionsByValues(array $values, array $reference = []): void
+    public function setOptionsByValues(array $values, array $reference = []): self
     {
         $this->setOptions([]);
         foreach ($values as $option) {
@@ -76,9 +105,10 @@ class FieldOptionsEvent extends Event
         }
 
         $this->dirty = true;
+        return $this;
     }
 
-    public function setOptionsByKeyValue(array $options): void
+    public function setOptionsByKeyValue(array $options): self
     {
         $this->setOptions([]);
         foreach ($options as $key => $value) {
@@ -86,12 +116,14 @@ class FieldOptionsEvent extends Event
         }
 
         $this->dirty = true;
+        return $this;
     }
 
-    public function setEmptyOption(bool $emptyOption, string $label = '-'): void
+    public function setEmptyOption(bool $emptyOption, string $label = '-'): self
     {
         $this->emptyOption = $emptyOption;
         $this->emptyOptionLabel = $label;
+        return $this;
     }
 
     public function isEmptyOption(): bool


### PR DESCRIPTION
This pull request enhances the handling of field options for form widgets, introducing support for grouped and sorted options, and making the API more fluent by allowing method chaining. The most important changes are grouped below:

**Field Options API Enhancements:**

* Added `grouped` and `sorted` properties (with corresponding `isGrouped`, `setGrouped`, `isSorted`, and `setSorted` methods) to the `FieldOptionsEvent` class to allow field options to be grouped and/or sorted. [[1]](diffhunk://#diff-92fcbd98244a14ae4d00fce7743ea0926fa6bfdb245f9f9540b3a380b68541deL12-R22) [[2]](diffhunk://#diff-92fcbd98244a14ae4d00fce7743ea0926fa6bfdb245f9f9540b3a380b68541deR71-R126)
* Updated several methods in `FieldOptionsEvent` (`addOption`, `setOptions`, `setOptionsByValues`, `setOptionsByKeyValue`, `setEmptyOption`) to return `$this` for method chaining, improving developer ergonomics. [[1]](diffhunk://#diff-92fcbd98244a14ae4d00fce7743ea0926fa6bfdb245f9f9540b3a380b68541deL31-R58) [[2]](diffhunk://#diff-92fcbd98244a14ae4d00fce7743ea0926fa6bfdb245f9f9540b3a380b68541deR71-R126)
* Extended the `addOption` and `createOptions` methods to support an optional `group` parameter, enabling assignment of options to groups.

**Option Formatting Logic:**

* In `FormGeneratorListener`, added logic to format options as grouped or ungrouped based on the event's `grouped` and `sorted` flags, using new helper methods `formatGroupedOptions` and `formatUngroupedOptions`. This includes sorting and inserting group headers as needed.

These changes make it easier to build dynamic, organized, and user-friendly option lists for forms.